### PR TITLE
Add runtime dependency to minitar

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
   s.add_dependency 'json_pure',  '~> 1.8'
+  s.add_dependency 'minitar'
 
   s.add_dependency 'faraday',                       '~> 0.9.0'
   s.add_dependency 'faraday_middleware',            '~> 0.9.0'


### PR DESCRIPTION
Without minitar gem installed r10k bails out with "cannot load such file -- archive/tar/minitar (LoadError)"